### PR TITLE
Fix undefined variable error in pipeline_echo_mimic.py

### DIFF
--- a/src/pipelines/pipeline_echo_mimic_pose.py
+++ b/src/pipelines/pipeline_echo_mimic_pose.py
@@ -457,6 +457,7 @@ class AudioPose2VideoPipeline(DiffusionPipeline):
         )
         
         face_locator_tensor = self.face_locator(face_mask_tensor)
+        zero_locator_tensor = torch.zeros_like(face_locator_tensor)
         
         extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an undefined variable error in the `pipeline_echo_mimic.py` script.

### What is the error?
The error occurs when `zero_locator_tensor` is used before it is defined, causing the script to crash.

### How does this fix it?
This fix ensures that `zero_locator_tensor` is defined before it is used, preventing the undefined variable error and allowing the script to run correctly.