### PR TITLE
fix cv2 Bad arguments in resize

### DIFF
--- a/webgui.py
+++ b/webgui.py
@@ -164,8 +164,8 @@ def process_video(uploaded_img, uploaded_audio, width, height, length, seed, fac
         r_pad_crop = int((re - rb) * facecrop_dilation_ratio)
         c_pad_crop = int((ce - cb) * facecrop_dilation_ratio)
         crop_rect = [max(0, cb - c_pad_crop), max(0, rb - r_pad_crop), min(ce + c_pad_crop, face_img.shape[1]), min(re + r_pad_crop, face_img.shape[0])]
-        face_img = crop_and_pad(face_img, crop_rect)
-        face_mask = crop_and_pad(face_mask, crop_rect)
+        face_img,_ = crop_and_pad(face_img, crop_rect)
+        face_mask,_ = crop_and_pad(face_mask, crop_rect)
         face_img = cv2.resize(face_img, (width, height))
         face_mask = cv2.resize(face_mask, (width, height))
 


### PR DESCRIPTION
 fix bug #90 :
cv2.error: OpenCV(4.10.0) :-1: error: (-5:Bad argument) in function 'resize'