### PR TITLE
Fix the bug in the inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ Terminal Technology Department, Alipay, Ant Group.
 
 </table>
 
+### Audio Driven after fix the bug in schedule of inference
+
+Left: After fixing the bug; Right: Before fixing the bug;
+Fix the bug will remove the noise of background.
+
+<table class="center">
+    
+<tr>
+    <td width=50% style="border: none">
+        <video controls loop src="https://github.com/user-attachments/assets/66b40f9a-69d9-4dba-853a-cbb7796ee9e2" muted="false"></video>
+    </td>
+    <td width=50% style="border: none">
+        <video controls loop src="https://github.com/user-attachments/assets/49a8c966-1ba9-4178-8650-b7919e266767" muted="false"></video>
+    </td>
+</tr>
+
+</table>
+
+
+
+
+
 **（Some demo images above are sourced from image websites. If there is any infringement, we will immediately remove them and apologize.）**
 
 ## Installation

--- a/configs/inference/inference_v2.yaml
+++ b/configs/inference/inference_v2.yaml
@@ -25,7 +25,7 @@ unet_additional_kwargs:
 noise_scheduler_kwargs:
   beta_start: 0.00085
   beta_end: 0.012
-  beta_schedule: "linear"
+  beta_schedule: "scaled_linear"
   clip_sample: false
   steps_offset: 1
   ### Zero-SNR params


### PR DESCRIPTION
Since I saw that the background was noisy in the previous generation, and I guessed that it could be due to the effect of moore's codebase, I guessed that you still used the "scaled linear" schedule during training, but the inference of moore's codebase is "linear" by default schedule, which is the same as your current inference, so I changed your inference to a "scaled linear" schedule (after aligning it with the training), the background noise was eliminated.